### PR TITLE
feat: add cancellation charge percentage

### DIFF
--- a/components/RefundResult.tsx
+++ b/components/RefundResult.tsx
@@ -1,24 +1,27 @@
-interface RefundResultProps {
-  result: {
+export interface RefundResultProps {
+    totalAmount: number;
     refundAmount: number;
     cancellationCharge: number;
-  };
+    cancellationPercentage: number;
 }
 
-export function RefundResult({ result }: RefundResultProps) {
+export function RefundResult(result : RefundResultProps) {
   return (
     <div className="mt-6 space-y-4">
       <div className="grid grid-cols-2 gap-4">
         <div className="p-4 bg-green-50 dark:bg-green-900/20 rounded-lg">
           <p className="text-sm text-green-600 dark:text-green-400">Refund Amount</p>
             <p className="text-2xl font-bold text-green-700 dark:text-green-300">
-            ₹{(result.refundAmount-20 < 0 ? 0 : (result.refundAmount-20)).toFixed(2)}
+            ₹{(result.refundAmount).toFixed(2)}
             </p>
         </div>
         <div className="p-4 bg-red-50 dark:bg-red-900/20 rounded-lg">
           <p className="text-sm text-red-600 dark:text-red-400">Cancellation Charges</p>
             <p className="text-2xl font-bold text-red-700 dark:text-red-300">
-            ₹{(result.refundAmount < 20 ? result.cancellationCharge : result.cancellationCharge+20).toFixed(2)}
+            ₹{(result.cancellationCharge).toFixed(2)}
+            <p className="text-xl font-light">
+            {result.cancellationPercentage.toFixed(1)}% of total cost ₹{result.totalAmount.toFixed(2)}
+            </p>
             </p>
         </div>
       </div>

--- a/components/refund-calculator.tsx
+++ b/components/refund-calculator.tsx
@@ -15,7 +15,7 @@ import { TICKET_TYPES, TRAIN_CLASSES, CANCELLATION_TIMES } from '@/lib/constants
 import { calculateRefund } from '@/lib/calculate-refund';
 import { PageHeader } from '@/components/PageHeader';
 import { MenuToggle } from '@/components/MenuToggle';
-import { RefundResult } from '@/components/RefundResult';
+import { RefundResult, RefundResultProps } from '@/components/RefundResult';
 import { CancellationRules } from '@/components/CancellationRules';
 import { Footer } from '@/components/Footer';
 
@@ -28,7 +28,7 @@ const formSchema = z.object({
 });
 
 export function RefundCalculator() {
-  const [result, setResult] = useState<{ refundAmount: number; cancellationCharge: number } | null>(null);
+  const [result, setResult] = useState<RefundResultProps | null>(null);
   const [selectedMenu, setSelectedMenu] = useState<'calculator' | 'rules'>('calculator');
 
   const form = useForm<z.infer<typeof formSchema>>({
@@ -194,7 +194,7 @@ export function RefundCalculator() {
                   </Button>
                 </form>
               </Form>
-              {result && <RefundResult result={result} />}
+              {result && <RefundResult {...result} />}
             </Card>
             <Alert className="mt-6">
               <AlertCircle className="h-4 w-4" />


### PR DESCRIPTION
## Changes
- Fixed a small issue with the cancellation charges. According to [IRCTC cancellation rules](https://contents.irctc.co.in/en/CancellationRulesforIRCTCTrain.pdf), the cancellation fee of ₹20 is applicable only for `RAC/Waitlisted ticket` that were cancelled four hours before the Scheduled Departure of the Train. Previously this cancellation fee applied for all the tickets which I think is not valid.

- I thought it would be nice if we also show the cancellation charges in terms of percentages as well so added it. Let me know what you think
<img width="671" alt="image" src="https://github.com/user-attachments/assets/0d1330bb-37a6-4514-8e4a-29e1da0daefd" />
